### PR TITLE
Configuração do puma como servidor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'vuejs-rails'
 
 group :production do
   gem 'pg'
+  gem 'puma'
   gem 'rails_12factor'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
+    puma (2.11.0)
+      rack (>= 1.1, < 2.0)
     rack (1.6.0)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -257,6 +259,7 @@ DEPENDENCIES
   overcommit
   pg
   pry-rails
+  puma
   rails (= 4.2)
   rails-env
   rails_12factor

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,3 +16,4 @@ production:
   database: rubyjobs_production
   username: root
   password:
+  pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,13 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Esse PR configura a aplicação para utilizar o `puma` como servidor.

O próprio heroku o recomenda (https://devcenter.heroku.com/changelog-items/594)