### PR TITLE
Adicionando Tipo de Contrato para um `Job`

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -59,6 +59,7 @@ class JobsController < ApplicationController
       :description,
       :modality,
       :website,
+      :contract_type,
       :salary)
   end
 end

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -13,7 +13,7 @@ module JobsHelper
   end
 
   def modalities_hash
-    {'Presencial' => :presencial, 'Remoto' => :remote, 'Freela' => :freela, 'Trainee' => :trainee}
+    { 'Presencial' => :presencial, 'Remoto' => :remote, 'Freela' => :freela, 'Trainee' => :trainee }
   end
 
   def salaries_hash

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -17,7 +17,11 @@ module JobsHelper
   end
 
   def salaries_hash
-    {'N/A' => :undefined, 'Abaixo de R$3.000' => :intern, 'R$3.000 - R$6.000' => :junior, 
+    { 'N/A' => :undefined, 'Abaixo de R$3.000' => :intern, 'R$3.000 - R$6.000' => :junior,
       'R$6.000 - R$9.000' => :medium, 'Acima de R$9.000' => :senior }
+  end
+
+  def contract_types_hash
+    { 'Não Especificado' => :not_specified, 'CLT' => :clt, 'PJ' => :pj }
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -11,6 +11,7 @@ class Job < ActiveRecord::Base
   # enumerator
   enum modality: { presencial: 0, remote: 1, freela: 2, trainee: 3 }
   enum salary: { undefined: 0, intern: 1, junior: 2, medium: 3, senior: 4 }
+  enum contract_type: { not_specified: 0, clt: 1, pj: 2 }
 
   def badge
     "#{modality}-badge.png"
@@ -22,5 +23,9 @@ class Job < ActiveRecord::Base
 
   def salary_label
     ['N/A', 'Abaixo de R$3.000', 'R$3.000 - R$6.000', 'R$6.000 - R$9.000', 'Acima de R$9.000'][Job.salaries[salary]]
+  end
+
+  def contract_type_label
+    ['Não Especificado', 'CLT', 'PJ'][Job.contract_types[contract_type]]
   end
 end

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -11,6 +11,7 @@
       <%= f.input :url, as: :url %>
       <%= f.input :skills %>
       <%= f.input :description %>
+      <%= f.input :contract_type, as: :radio_buttons, collection: contract_types_hash %>
       <%= f.input :salary, as: :radio_buttons, collection: salaries_hash %>
       <!--
       <%= f.label :description %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -33,7 +33,11 @@
     </div>
 
     <%= content_tag :div do %>
-      Salário <%= @job.salary_label %>
+      Tipo de Contratação: <%= @job.contract_type_label %>
+    <% end %>
+
+    <%= content_tag :div do %>
+      Salário: <%= @job.salary_label %>
     <% end %>
 
     <%= content_tag :div, class: "well skills" do %>

--- a/config/locales/jobs.yml
+++ b/config/locales/jobs.yml
@@ -20,6 +20,7 @@ pt-BR:
         skills: "Habilidades/Requerimentos"
         description: "Descrição"
         salary: "Salário"
+        contract_type: "Tipo de Contratação"
     placeholders:
       job:
         title: "Desenvolvedor Ruby on Rails"

--- a/db/migrate/20150224002400_add_contrat_type_to_jobs.rb
+++ b/db/migrate/20150224002400_add_contrat_type_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddContratTypeToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :contract_type, :integer, default: 0, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150120095819) do
+ActiveRecord::Schema.define(version: 20150224002400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,10 +26,11 @@ ActiveRecord::Schema.define(version: 20150120095819) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "slug"
-    t.integer  "modality",    default: 0
+    t.integer  "modality",      default: 0
     t.string   "website"
-    t.integer  "salary",      default: 0
+    t.integer  "salary",        default: 0
     t.string   "url"
+    t.integer  "contract_type", default: 0
   end
 
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -28,4 +28,28 @@ describe Job do
     subject(:job) { build(:job, email: 'm@e.com') }
     it { expect(job).not_to be_valid }
   end
+
+  describe '#contract_type_label' do
+    subject(:job) do
+      build(:job, contract_type: contract_type).contract_type_label
+    end
+
+    context 'Not Speficied' do
+      let(:contract_type) { 0 }
+
+      it { is_expected.to eq 'Não Especificado' }
+    end
+
+    context 'CLT' do
+      let(:contract_type) { 1 }
+
+      it { is_expected.to eq 'CLT' }
+    end
+
+    context 'PJ' do
+      let(:contract_type) { 2 }
+
+      it { is_expected.to eq 'PJ' }
+    end
+  end
 end


### PR DESCRIPTION
Agora o usuário tem a opção de informar se o tipo de contratação é CLT ou PJ. A opção padrão é "Não Especificado".

Algumas pessoas estavam colocando que a vaga era PJ espalhado pela descrição da vaga. Assim será mais fácil de visualizar e tirará qualquer dúvida de quem estiver interessado na vaga.