### PR TITLE
Colocando em destaque tipo de contratação e salário

### DIFF
--- a/app/assets/stylesheets/pages/_job_show.scss
+++ b/app/assets/stylesheets/pages/_job_show.scss
@@ -1,9 +1,27 @@
 #jobs-show {
 
+  .job-contract-type-not_specified,
+  .job-salary-undefined {
+    color: $base-color;
+  }
+
+  .job-salary-intern,
+  .job-salary-junior,
+  .job-salary-medium,
+  .job-salary-senior {
+    color: #44df57;
+  }
+
+  .job-contract-type-clt,
+  .job-contract-type-pj {
+    color: #4578ca;
+  }
+
   .page-header{
     span {
       margin-right: 15px;
     }
+
     span.job-date {
       color: #b6bac2;
     }
@@ -17,7 +35,7 @@
   }
 
   .job-description{
-    line-height: 150%;  
+    line-height: 150%;
   }
 
   .do-you-like-it {
@@ -53,5 +71,4 @@
       text-align: center;
     }
   }
-
 }

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -25,20 +25,15 @@
         <% end %>
         <%= content_tag :span, "#{@job.location}/#{@job.modality_name}", class: "job-location" %>
         <%= content_tag :span, l(@job.created_at, format: :long), class: "job-date" %>
+        <%= content_tag :span, %(Contratação: #{@job.contract_type_label}), format: :long,
+          class: "job-contract-type-#{@job.contract_type}" %>
+        <%= content_tag :span, %(Salário: #{@job.salary_label}), format: :long, class: "job-salary-#{@job.salary}" %>
       </p>
     </div>
 
     <div class="job-description">
       <%= markdown @job.description %>
     </div>
-
-    <%= content_tag :div do %>
-      Tipo de Contratação: <%= @job.contract_type_label %>
-    <% end %>
-
-    <%= content_tag :div do %>
-      Salário: <%= @job.salary_label %>
-    <% end %>
 
     <%= content_tag :div, class: "well skills" do %>
       <h4> Habilidades </h4>


### PR DESCRIPTION
Issue #30

* Tipo de contratação e salário movidos para o topo, na mesma parte em que se encontram a data do `job`, nome da empresa, remoto ou não, etc.
* Caso um dos valores não tenha sido especificado ele será representado na cor vermelha.
* Tipo de contratação presente = azul
* Salário presente = verde

![screen shot 2015-02-27 at 12 04 24 am](https://cloud.githubusercontent.com/assets/1480149/6406861/5c0ffc0c-be14-11e4-8bfe-5926a7767e51.png)
