### PR TITLE
Adição de nova opção de salário.

### DIFF
--- a/app/assets/stylesheets/pages/_job_show.scss
+++ b/app/assets/stylesheets/pages/_job_show.scss
@@ -8,7 +8,8 @@
   .job-salary-intern,
   .job-salary-junior,
   .job-salary-medium,
-  .job-salary-senior {
+  .job-salary-senior,
+  .job-salary-value_by_hour {
     color: #44df57;
   }
 

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -31,7 +31,8 @@ module JobsHelper
 
   def salaries_hash
     { 'N/A' => :undefined, 'Abaixo de R$3.000' => :intern, 'R$3.000 - R$6.000' => :junior,
-      'R$6.000 - R$9.000' => :medium, 'Acima de R$9.000' => :senior }
+      'R$6.000 - R$9.000' => :medium, 'Acima de R$9.000' => :senior,
+      'Valor hora a combinar' => :value_by_hour  }
   end
 
   def contract_types_hash

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -10,6 +10,6 @@ class Job < ActiveRecord::Base
 
   # enumerator
   enum modality: { presencial: 0, remote: 1, freela: 2, trainee: 3 }
-  enum salary: { undefined: 0, intern: 1, junior: 2, medium: 3, senior: 4 }
+  enum salary: { undefined: 0, intern: 1, junior: 2, medium: 3, senior: 4, value_by_hour: 5 }
   enum contract_type: { not_specified: 0, clt: 1, pj: 2 }
 end

--- a/app/presenters/job_presenter.rb
+++ b/app/presenters/job_presenter.rb
@@ -13,7 +13,8 @@ class JobPresenter < Burgundy::Item
       Abaixo\ de\ R$3.000
       R$3.000\ -\ R$6.000
       R$6.000\ -\ R$9.000
-      Acima\ de\ R$9.000)[Job.salaries[salary]]
+      Acima\ de\ R$9.000
+      Valor\ hora\ a\ combinar)[Job.salaries[salary]]
   end
 
   def contract_type_label

--- a/spec/presenters/job_presenter_spec.rb
+++ b/spec/presenters/job_presenter_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe JobPresenter do
       { name: 'Intern', label: 'Abaixo de R$3.000' },
       { name: 'Junior', label: 'R$3.000 - R$6.000' },
       { name: 'Medium', label: 'R$6.000 - R$9.000' },
-      { name: 'Senior', label: 'Acima de R$9.000' }
+      { name: 'Senior', label: 'Acima de R$9.000' },
+      { name: 'Value by Hour', label: 'Valor hora a combinar' }
     ]
 
     salaries.each_with_index do |item, index|


### PR DESCRIPTION
Empresas que contratam PJ's geralmente tem duas opções de pagamento: Valor fixo no mês ou valor por hora de alocação, então criei essa nova opção no cadastro.

![value-hora](https://cloud.githubusercontent.com/assets/2160392/7692817/012009d4-fd9f-11e4-8295-264d511c7099.png)
