### PR TITLE
Atualizar ruby, puma e pg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.2.3
 before_script:
   - bundle exec rubocop -D
   - cp config/database.yml.example config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.2'
+ruby '2.2.3'
 
 gem 'rails', '4.2.1'
 gem 'pg', '~> 0.18.1'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.2.3'
 
 gem 'rails', '4.2.1'
-gem 'pg', '~> 0.18.1'
+gem 'pg'
 gem 'angularjs-rails'
 gem 'anjlab-bootstrap-rails', require: 'bootstrap-rails',
                               github: 'anjlab/bootstrap-rails',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       iniparse (~> 1.4)
     parser (2.2.2.2)
       ast (>= 1.1, < 3.0)
-    pg (0.18.1)
+    pg (0.18.3)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -264,7 +264,7 @@ DEPENDENCIES
   kaminari
   marked-rails
   overcommit
-  pg (~> 0.18.1)
+  pg
   pry-rails
   puma
   rails (= 4.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,9 +139,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.11.2)
-      rack (>= 1.1, < 2.0)
-    rack (1.6.0)
+    puma (2.14.0)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.1)
@@ -285,4 +284,4 @@ DEPENDENCIES
   vuejs-rails
 
 BUNDLED WITH
-   1.10.5
+   1.10.6


### PR DESCRIPTION
Fui atualizar para o ruby 2.2.3 e a versão anterior do puma estava dando erro na instalação, daí aproveitei e atualizei ele também.

Atualizei a `pg` só por atualizar mesmo. :smile: 