### PR TITLE
Corrige layout mobile responsivo

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <header id="home">
   <div class="container">
-    <%= image_tag "logo-with-banner.png", class: "logo" %>
+    <%= image_tag "logo-with-banner.png", class: "logo img-responsive" %>
     <h2>Está precisando de um Rubista?</h2>
     <p> Anuncie sua vaga no RubyJobs e deixe mais de 4000 desenvolvedores saberem da sua vaga. </p>
     <%= link_to "Anuncie uma vaga!", new_job_path, class: "btn btn-ghost"%>
@@ -16,21 +16,23 @@
         <div class="page-header">
           <h1>Vagas recentes</h1>
         </div>
-        <table class="jobs-list">
-          <% @jobs.each do |job| %>
+        <div class="table-responsive">
+          <table class="jobs-list">
+            <% @jobs.each do |job| %>
             <tr class="<%= job.modality %>">
               <%= content_tag :td, image_tag(job.badge), class: "job-badge" %>
               <%= content_tag :td, class: "job-title-company" do %>
-                <%= content_tag :p, (link_to (truncate(job.title, :length => 50)), job_path(job)), class: "job-title" %>
-                <%= content_tag :p, (truncate(job.company, :length => 40)), class: "job-company" %>
+              <%= content_tag :p, (link_to (truncate(job.title, :length => 50)), job_path(job)), class: "job-title" %>
+              <%= content_tag :p, (truncate(job.company, :length => 40)), class: "job-company" %>
               <% end %>
               <%= content_tag :td, (truncate(job.location, :length => 28)), class: "job-location" %>
               <td class="job-date badger-right badger-<%= job.modality %>" data-badger="<%= job.modality_name %>">
                 <%= job.created_at.strftime("%d/%m/%Y") %>
               </td>
             </tr>
-          <% end %>
-        </table>
+            <% end %>
+          </table>
+        </div>
         <%= link_to "Ver + vagas", :jobs, class: "show-more-jobs" %>
       </div>
     </div>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -14,26 +14,28 @@
 
         <input type="text" placeholder="Que tipo de trabalho você esta procurando?" ng-model="search" class="form-control"><br/>
 
-        <table class="jobs-list">
-          <tbody infinite-scroll="loadMore()" infinite-scroll-distance="3">
-            <tr class="{{::job.modality}}" ng-repeat="job in jobs | filter:search">
-              <td class="job-badge"><img ng-src="{{::job.badge}}"></td>
-              <td class="job-title"><a ng-href="{{::job.url}}">{{::job.title}}</a></td>
-              <td class="job-company">
-                <a ng-href="{{::job.website}}" ng-if="job.website">
-                  {{::job.company}}
-                </a>
-                <span ng-if="!job.website">
-                  {{::job.company}}
-                </span>
-              </td>
-              <td class="job-location"> {{::job.location}} </td>
-              <td class="job-date badger-right badger-{{::job.modality}}" data-badger="{{job.modality_name}}">
-                {{job.posted_at | date:'dd/MM/yyyy'}}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <div class="table-responsive">
+          <table class="jobs-list">
+            <tbody infinite-scroll="loadMore()" infinite-scroll-distance="3">
+              <tr class="{{::job.modality}}" ng-repeat="job in jobs | filter:search">
+                <td class="job-badge"><img ng-src="{{::job.badge}}"></td>
+                <td class="job-title"><a ng-href="{{::job.url}}">{{::job.title}}</a></td>
+                <td class="job-company">
+                  <a ng-href="{{::job.website}}" ng-if="job.website">
+                    {{::job.company}}
+                  </a>
+                  <span ng-if="!job.website">
+                    {{::job.company}}
+                  </span>
+                </td>
+                <td class="job-location"> {{::job.location}} </td>
+                <td class="job-date badger-right badger-{{::job.modality}}" data-badger="{{job.modality_name}}">
+                  {{job.posted_at | date:'dd/MM/yyyy'}}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
         <div class="spinner" ng-show="loading">
           <div class="rect1"></div>


### PR DESCRIPTION
Como reportado pelo @fabianoarruda na #90 o layout da aplicação acabava quebrando em alguns tamanhas de tela de smartphones.

Para melhorar a experiência do usuário mobile eu acabei por fazer o seguinte:

- Coloquei a tabela de jobs dentre de uma div de tabela responsiva do bootstrap
- A image de logo da home page também foi movida para dentro de uma div responsiva.

Testei em um android onde o layout apresentava o mesmo problemas, e no emulador de dispositivos do chrome.

Após as alterações, layout ok em mobile, tudo certo.

![img_20160507_113917](https://cloud.githubusercontent.com/assets/706049/15092715/67a47e9a-1448-11e6-8976-57e80b844b0d.jpg)

